### PR TITLE
Fix race condition causing 'Address already in use' errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,41 +116,39 @@ func main() {
 	}()
 
 	// First run the command
-	runCommand(ctx, command, fileChanges)
+	changedFile := runCommand(ctx, command, fileChanges)
 
 	// Then rerun it on file changes
-	for name := range fileChanges {
+	for {
+		// Check if we got a changed file from runCommand, otherwise wait for one
+		var name string
+		if changedFile != "" {
+			name = changedFile
+			changedFile = ""
+		} else {
+			var ok bool
+			name, ok = <-fileChanges
+			if !ok {
+				break
+			}
+		}
 		fmt.Fprintf(os.Stderr, "--- Changed: %s\n", name)
 		fmt.Fprintf(os.Stderr, "--- Running: %s\n", command)
-		runCommand(ctx, command, fileChanges)
+		changedFile = runCommand(ctx, command, fileChanges)
 	}
 
 	// Wait until all goroutines are done
 	wg.Wait()
 }
 
-func runCommand(ctx context.Context, command string, fileChanges chan string) {
+// runCommand runs a command and returns the name of the file that changed
+// if the command was interrupted by a file change, or an empty string if
+// the command completed normally or the context was cancelled.
+func runCommand(ctx context.Context, command string, fileChanges chan string) string {
 	// Create child context so we can cancel this command
 	// without cancelling the entire program
 	commandCtx, commandCancel := context.WithCancel(ctx)
 	defer commandCancel()
-
-	// Cancel and rerun the command if the file changes
-	// while we run the command
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		name, ok := <-fileChanges
-		// The channel was closed, shut down
-		if !ok {
-			return
-		}
-		commandCancel()
-		// Send the file change back on the channel
-		// to trigger `runCommand` again
-		fileChanges <- name
-	}()
 
 	// Run the command using `sh -c <command>` to allow for
 	// shell syntax such as pipes and boolean operators
@@ -158,12 +156,14 @@ func runCommand(ctx context.Context, command string, fileChanges chan string) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	// Set process group so we can kill all child processes
+	// Set process group so we can kill all child processes.
+	// This makes the spawned process the leader of a new process group,
+	// allowing us to kill it and all its descendants with a single signal.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	// Start the command
 	if err := cmd.Start(); err != nil {
-		return
+		return ""
 	}
 
 	// Wait for completion in a goroutine
@@ -172,16 +172,34 @@ func runCommand(ctx context.Context, command string, fileChanges chan string) {
 		done <- cmd.Wait()
 	}()
 
-	// Wait for either completion or cancellation
+	// killProcessGroup sends SIGKILL to the entire process group
+	killProcessGroup := func() {
+		pgid, err := syscall.Getpgid(cmd.Process.Pid)
+		if err != nil {
+			// Fallback to just killing the main process
+			_ = cmd.Process.Kill()
+			return
+		}
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	}
+
+	// Wait for either completion, cancellation, or file change
 	select {
 	case <-commandCtx.Done():
-		// Kill the entire process group (negative PID)
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		killProcessGroup()
 		<-done // Wait for process to actually exit
+		return ""
 	case <-done:
 		// Command completed normally
+		return ""
+	case name, ok := <-fileChanges:
+		if !ok {
+			return ""
+		}
+		killProcessGroup()
+		<-done // Wait for process to actually exit
+		return name
 	}
-	wg.Wait()
 }
 
 func check(err error) {


### PR DESCRIPTION
## Problem

When using `reload` with commands that start long-running servers (e.g., `reload make serve` where the Makefile runs `python3 -m http.server`), file changes would cause "Address already in use" errors:

```
--- Changed: /path/to/file.go
--- Running: make serve
...
OSError: [Errno 48] Address already in use
make: *** [serve] Error 1
```

## Root Cause

The previous implementation had a race condition in how file change events were handled:

1. A background goroutine in `runCommand()` would receive a file change event from the `fileChanges` channel
2. It would call `commandCancel()` to cancel the context
3. It would **immediately** send the filename back to the channel to trigger a restart
4. The main loop would receive this and call `runCommand()` again
5. The new command would start **before** the old process group was killed

This meant two instances of the server could be running simultaneously, with the second one failing because the port was still in use.

## Solution

The fix restructures `runCommand()` to handle file change events properly:

1. **Move file change handling into the main select statement** - Instead of a separate goroutine, file changes are now handled alongside command completion and context cancellation in a single `select`

2. **Kill before returning** - When a file change occurs, we now:
   - Kill the entire process group
   - Wait for the process to actually exit
   - Only then return the filename to the caller

3. **Return instead of channel send** - The function now returns the changed filename instead of sending it back through the channel, ensuring proper sequencing

4. **Use `syscall.Getpgid()` for process group ID** - More reliable than assuming PGID equals PID

## Testing

Tested with `reload make serve` where the Makefile runs a Python HTTP server. Multiple rapid file changes no longer cause port conflicts - each restart cleanly kills the previous server before starting a new one.